### PR TITLE
feat: add sampling-rate option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Options
 ```typescript
 type appinsightOptions = {
   name?: string // Optional. Name of the application
+  samplingPercentage?: number // Optional. Reduce the amount of telemetry collected
 }
 ```
 
@@ -39,6 +40,11 @@ Bynyan messages (used by @kth/log) will be desctructured, and only the "msg" fie
 
 Example:  
 `{ name: "my-app", level: 30, msg: "the important part" }` will be reduced to just `"the important part"`.
+
+### Telemetry Sampling
+
+Used to reduce the amount of telemetry collected, primary used to reduce cost.
+Enable with option `samplingPercentage`. Default is 100% = everything is collected.
 
 ### Track operations for Agenda jobs
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -17,6 +17,7 @@ describe('init applicationinsights', () => {
     process.env.APPLICATIONINSIGHTS_CONNECTION_STRING = 'default-connection-string'
 
     applicationinsightsMock.defaultClient.context.tags = {}
+    applicationinsightsMock.defaultClient.config = {}
 
     mockOs.hostname.mockReturnValue('host1234')
   })
@@ -93,6 +94,18 @@ describe('init applicationinsights', () => {
       KthAppinsights.init({ name: 'my_application' })
 
       expect(Object.keys(applicationinsightsMock.defaultClient.context.tags)).not.toContain('ai.cloud.roleInstance')
+    })
+  })
+  describe('sampling', () => {
+    beforeEach(() => {})
+    it('sets if "samplingPercentage" is included in options', () => {
+      KthAppinsights.init({ samplingPercentage: 50 })
+
+      expect(applicationinsightsMock.defaultClient.config.samplingPercentage).toBe(50)
+    })
+    it('does not set without "samplingPercentage" in options', () => {
+      KthAppinsights.init({})
+      expect(Object.keys(applicationinsightsMock.defaultClient.config)).not.toContain('samplingPercentage')
     })
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ type appinsightOptions = {
   name?: string
   connectionString?: string
   instrumentationKey?: string
+  samplingPercentage?: number
 }
 
 import * as appInsights from 'applicationinsights'
@@ -20,6 +21,10 @@ const init = (options: appinsightOptions) => {
   if (options.name) {
     setRoleName(options.name)
     setInstanceName(options.name)
+  }
+
+  if (options.samplingPercentage) {
+    appInsights.defaultClient.config.samplingPercentage = options.samplingPercentage
   }
 
   appInsights.defaultClient.addTelemetryProcessor(userAgentOnRequest)


### PR DESCRIPTION
Used to optionally reduce amount of metrics. Some apps have quite expensive logs.